### PR TITLE
Breaking changes for next major version

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,18 +1,11 @@
 {
     "presets": [
-        [
-            "@babel/preset-env",
-            {
-                "targets": {
-                    "node": "current"
-                }
-            }
-        ],
+        "@babel/preset-env",
         "@babel/preset-react"
     ],
     "plugins": [
+        "@babel/plugin-transform-runtime",
         "@babel/plugin-proposal-class-properties",
-        "@babel/plugin-proposal-object-rest-spread",
         [
             "babel-plugin-styled-components",
             {
@@ -21,5 +14,19 @@
                 "fileName": false
             }
         ]
-    ]
+    ],
+    "env": {
+        "test": {
+            "presets": [
+                [
+                    "@babel/preset-env",
+                    {
+                        "targets": {
+                            "node": "current"
+                        }
+                    }
+                ]
+            ]
+        }
+    }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,8 @@ module.exports = {
     ],
     rules: {
         'compat/compat': 0,
+        'import/no-namespace': 0,                          // importing bacon.js in a way that supports all versions
+        'react/static-property-placement': 0,              // need to remove propTypes from prod builds
     },
     globals: {
         process: 'readonly',

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+/coverage/
+.DS_Store
+/.idea/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT LICENSE
 
-Copyright 2018 Steve Taylor
+Copyright 2018-2019 Steve Taylor
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 if (process.env.NODE_ENV === 'production') {
-    module.exports = require('./isoreact-bacon1.cjs.min.js');
+    module.exports = require('./isoreact-bacon.cjs.min.js');
 } else {
-    module.exports = require('./isoreact-bacon1.cjs.js');
+    module.exports = require('./isoreact-bacon.cjs.js');
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@isoreact/bacon1",
+  "name": "@isoreact/bacon",
   "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -8,7 +8,6 @@
       "version": "7.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/code-frame/-/code-frame-7.0.0.tgz",
       "integrity": "sha1-BuKrGb21NThVWaq7W6WXKUgoAPg=",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.0.0"
       }
@@ -17,7 +16,6 @@
       "version": "7.4.5",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/core/-/core-7.4.5.tgz",
       "integrity": "sha1-CB+X6P/KZam0sP3H4nTnA/AAwGo=",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/generator": "^7.4.4",
@@ -39,7 +37,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/generator/-/generator-7.4.4.tgz",
       "integrity": "sha1-F0ohXrhD/DksftyqvqqHPebo8EE=",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.4.4",
         "jsesc": "^2.5.1",
@@ -52,7 +49,6 @@
       "version": "7.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
       "integrity": "sha1-Mj053QtQ4Qx8Bsp9djjmhk2MXDI=",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -61,7 +57,6 @@
       "version": "7.1.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
       "integrity": "sha1-a2lijf5Ah3mODE7Zjj1Kay+9L18=",
-      "dev": true,
       "requires": {
         "@babel/helper-explode-assignable-expression": "^7.1.0",
         "@babel/types": "^7.0.0"
@@ -71,7 +66,6 @@
       "version": "7.3.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz",
       "integrity": "sha1-oayVpdKz6Irl5UhGv0Yu64GzGKQ=",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.3.0",
         "esutils": "^2.0.0"
@@ -81,7 +75,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
       "integrity": "sha1-h8H4yhmtVSpzanonscH8+LH/H0M=",
-      "dev": true,
       "requires": {
         "@babel/helper-hoist-variables": "^7.4.4",
         "@babel/traverse": "^7.4.4",
@@ -92,7 +85,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.4.tgz",
       "integrity": "sha1-/D1pCvZVTMnvxgc2SoLUj1hzbbo=",
-      "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-member-expression-to-functions": "^7.0.0",
@@ -106,7 +98,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
       "integrity": "sha1-aWnR9XC0a9yQDR66jl1ZxIuiwSo=",
-      "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
         "@babel/types": "^7.4.4",
@@ -117,7 +108,6 @@
       "version": "7.1.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
       "integrity": "sha1-U3+hP28WdN90WwwA7I/k6ZaByPY=",
-      "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
         "@babel/types": "^7.0.0"
@@ -127,7 +117,6 @@
       "version": "7.1.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
       "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
-      "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "^7.0.0",
         "@babel/template": "^7.1.0",
@@ -138,7 +127,6 @@
       "version": "7.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
       "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -147,7 +135,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
       "integrity": "sha1-Api18lyMCcUxAtUqxKmPdz6yhQo=",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.4.4"
       }
@@ -156,7 +143,6 @@
       "version": "7.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
       "integrity": "sha1-jNFLCg33/wDwCefXpDaUX0fHoW8=",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -165,7 +151,6 @@
       "version": "7.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
       "integrity": "sha1-lggbcRHkhtpNLNlxrRpP4hbMLj0=",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -174,7 +159,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
       "integrity": "sha1-lhFepCovE55hnpjtRt9gGblEFLg=",
-      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-simple-access": "^7.1.0",
@@ -188,7 +172,6 @@
       "version": "7.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
       "integrity": "sha1-opIMVwKwc8Fd5REGIAqoytIEl9U=",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -196,14 +179,12 @@
     "@babel/helper-plugin-utils": {
       "version": "7.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-      "integrity": "sha1-u7P77phmHFaQNCN8wDlnupm08lA=",
-      "dev": true
+      "integrity": "sha1-u7P77phmHFaQNCN8wDlnupm08lA="
     },
     "@babel/helper-regex": {
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
       "integrity": "sha1-pH4CvJH7JZ0uZyfCowAT46wTxKI=",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.11"
       }
@@ -212,7 +193,6 @@
       "version": "7.1.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
       "integrity": "sha1-Nh2AghtvONp1vT8HheziCojF/n8=",
-      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-wrap-function": "^7.1.0",
@@ -225,7 +205,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz",
       "integrity": "sha1-ruQXg+vk8tOrOud14cxvGpDO+ic=",
-      "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.0.0",
         "@babel/helper-optimise-call-expression": "^7.0.0",
@@ -237,7 +216,6 @@
       "version": "7.1.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
       "integrity": "sha1-Ze65VMjCRb6qToWdphiPOdceWFw=",
-      "dev": true,
       "requires": {
         "@babel/template": "^7.1.0",
         "@babel/types": "^7.0.0"
@@ -247,7 +225,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
       "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.4.4"
       }
@@ -256,7 +233,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
       "integrity": "sha1-xOABJEV2nigVtVKW6tQ6lYVJ9vo=",
-      "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
         "@babel/template": "^7.1.0",
@@ -268,7 +244,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/helpers/-/helpers-7.4.4.tgz",
       "integrity": "sha1-hosO9Zwd1OeHRFYtXOG1nIny8qU=",
-      "dev": true,
       "requires": {
         "@babel/template": "^7.4.4",
         "@babel/traverse": "^7.4.4",
@@ -279,7 +254,6 @@
       "version": "7.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/highlight/-/highlight-7.0.0.tgz",
       "integrity": "sha1-9xDDjI1Fjm3ZogGvtjf8t4HOmeQ=",
-      "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -289,14 +263,12 @@
     "@babel/parser": {
       "version": "7.4.5",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/parser/-/parser-7.4.5.tgz",
-      "integrity": "sha1-BK+NXVorBEoqG/+sweXmZzVE6HI=",
-      "dev": true
+      "integrity": "sha1-BK+NXVorBEoqG/+sweXmZzVE6HI="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
       "integrity": "sha1-somzBmadzkrSCwJSiJoVdoydQX4=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-remap-async-to-generator": "^7.1.0",
@@ -307,7 +279,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.4.4.tgz",
       "integrity": "sha1-k6ZIbu2G1TRSq5urNeNo6UYRmM4=",
-      "dev": true,
       "requires": {
         "@babel/helper-create-class-features-plugin": "^7.4.4",
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -317,7 +288,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
       "integrity": "sha1-Vo7MRGxhSK5rJn8CVREwiR4p8xc=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-json-strings": "^7.2.0"
@@ -327,7 +297,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz",
       "integrity": "sha1-HvFz/PJLPi35KmePAnZztV5+MAU=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
@@ -337,7 +306,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha1-E12B7baKCB5V5W7EhUHs6AZcOPU=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
@@ -347,7 +315,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
       "integrity": "sha1-UB/9mCbAuR2iJpByByKsfLHKnHg=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-regex": "^7.4.4",
@@ -358,7 +325,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
       "integrity": "sha1-aeHw2zTG9aDPfiszI78VmnbIy38=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -367,7 +333,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
       "integrity": "sha1-cr0T9v/h0lk4Ep0qGGsR/WKVFHA=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -376,7 +341,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
       "integrity": "sha1-C4WjtLx830zEuL8jYzW5B8oi58c=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -385,7 +349,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
       "integrity": "sha1-O3o+czUQxX6CC5FCpleayLDfrS4=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -394,7 +357,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha1-qUAT1u2okI3+akd+f57ahWVuz1w=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -403,7 +365,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
       "integrity": "sha1-mur75Nb/xlY7+Pg3IJFijwB3lVA=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -412,7 +373,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.4.tgz",
       "integrity": "sha1-o/HQHy8hytqyCzOoITMRbxT7WJQ=",
-      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -423,7 +383,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
       "integrity": "sha1-XTzBHo1d3XUqpkyRSNDbbLef0ZA=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -432,7 +391,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz",
       "integrity": "sha1-wTJ5+r9rkWZhUxhBojxLfa4pZG0=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "lodash": "^4.17.11"
@@ -442,7 +400,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz",
       "integrity": "sha1-DOQJTNr9cJchB207nDitMcpxXrY=",
-      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-define-map": "^7.4.4",
@@ -458,7 +415,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
       "integrity": "sha1-g6ffamWIZbHI9kHVEMbzryICFto=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -467,7 +423,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.4.tgz",
       "integrity": "sha1-nZZHF4KcyeS2AfyCompxpNj68g8=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -476,7 +431,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
       "integrity": "sha1-NhoUi8lRREMSxpRG127R6o5EUMM=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-regex": "^7.4.4",
@@ -487,7 +441,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
       "integrity": "sha1-2VLEkw8xKk2//xjwspFOYMNVMLM=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -496,7 +449,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
       "integrity": "sha1-pjhoKJ5bQAf3BU1GSRr1FDV2YAg=",
-      "dev": true,
       "requires": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -506,7 +458,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
       "integrity": "sha1-Amf8c14kyAi6FzhmxsTRRA/DxVY=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -515,7 +466,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
       "integrity": "sha1-4UNhFquwYQwiWQlISHVKxSMJIq0=",
-      "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -525,7 +475,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
       "integrity": "sha1-aQNT6B+SZ9rU/Yz9d+r6hqulPqE=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -534,7 +483,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
       "integrity": "sha1-+hCqXFiiy2r88sn/qMtNiz1Imi0=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -543,7 +491,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
       "integrity": "sha1-gqm85FuVRB9heiQBHcidEtp/TuY=",
-      "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "^7.1.0",
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -553,7 +500,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.4.tgz",
       "integrity": "sha1-C+9HE9MPHXjC5Zs9bbQOYBksrB4=",
-      "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "^7.4.4",
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -564,7 +510,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.4.tgz",
       "integrity": "sha1-3IPFZlsH1sKnsiTACsY2Weo2pAU=",
-      "dev": true,
       "requires": {
         "@babel/helper-hoist-variables": "^7.4.4",
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -574,7 +519,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
       "integrity": "sha1-dnjOdRafCHe46yI1U4wHQmjdAa4=",
-      "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "^7.1.0",
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -584,7 +528,6 @@
       "version": "7.4.5",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
       "integrity": "sha1-nSaf0oo3AlgZm0KUc2gTpgu90QY=",
-      "dev": true,
       "requires": {
         "regexp-tree": "^0.1.6"
       }
@@ -593,7 +536,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
       "integrity": "sha1-GNEgQ4sMye6VpH8scryXaPvtYKU=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -602,7 +544,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
       "integrity": "sha1-s11MEPVrq11lAEfa0PHY6IFLZZg=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-replace-supers": "^7.1.0"
@@ -612,7 +553,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
       "integrity": "sha1-dVbPA/MYvScZ/kySLS2Ai+VXHhY=",
-      "dev": true,
       "requires": {
         "@babel/helper-call-delegate": "^7.4.4",
         "@babel/helper-get-function-arity": "^7.0.0",
@@ -623,7 +563,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
       "integrity": "sha1-A+M/ZT9bJcTrVyyYuUhQVbOJ6QU=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -632,7 +571,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
       "integrity": "sha1-6/rth4NM6NxCeWCaTwwyTBVuPrA=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -641,7 +579,6 @@
       "version": "7.3.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz",
       "integrity": "sha1-8sq5kCZjHHZ+J0WlNoszHP6PUpA=",
-      "dev": true,
       "requires": {
         "@babel/helper-builder-react-jsx": "^7.3.0",
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -652,7 +589,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz",
       "integrity": "sha1-Rh4hrZR48QMd1eJ2EI0CfxtSQLo=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-jsx": "^7.2.0"
@@ -662,7 +598,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.2.0.tgz",
       "integrity": "sha1-IMjGDwFA9d081jQY1FKAHPP3GA8=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-jsx": "^7.2.0"
@@ -672,7 +607,6 @@
       "version": "7.4.5",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
       "integrity": "sha1-Yp3IJRLFXO4BNB+ye9/LIQNUaA8=",
-      "dev": true,
       "requires": {
         "regenerator-transform": "^0.14.0"
       }
@@ -681,16 +615,25 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
       "integrity": "sha1-R5Kvh8mYpJNnWX0H/t8CY20uFjQ=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.4.tgz",
+      "integrity": "sha512-aMVojEjPszvau3NRg+TIH14ynZLvPewH4xhlCW1w6A3rkxTS1m4uwzRclYR9oS+rl/dr+kT+pzbfHuAWP/lc7Q==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
       "integrity": "sha1-YzOu4vjW7n4oYVRXKYk0o7RhmPA=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -699,7 +642,6 @@
       "version": "7.2.2",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
       "integrity": "sha1-MQOpq+IvdCttQG7NPNSbd0kZtAY=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -708,7 +650,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
       "integrity": "sha1-oeRUtZlVYKnB4NU338FQYf0mh+E=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-regex": "^7.0.0"
@@ -718,7 +659,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
       "integrity": "sha1-nSj+p7vOY3+3YSoHUJidgyHUvLA=",
-      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -728,7 +668,6 @@
       "version": "7.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
       "integrity": "sha1-EX0rzsL79ktLWdH5gZiUaC0p8rI=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -737,7 +676,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
       "integrity": "sha1-q0Y0u08U02cov1l4Mis1WHeHlw8=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-regex": "^7.4.4",
@@ -748,7 +686,6 @@
       "version": "7.4.5",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/preset-env/-/preset-env-7.4.5.tgz",
       "integrity": "sha1-L61/Ypg9WvVjtfMTkkJ1WISZilg=",
-      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -804,7 +741,6 @@
       "version": "7.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/preset-react/-/preset-react-7.0.0.tgz",
       "integrity": "sha1-6GtLPZlDPHs+npF0fiZTlYvGs8A=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-transform-react-display-name": "^7.0.0",
@@ -815,9 +751,8 @@
     },
     "@babel/runtime": {
       "version": "7.4.5",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/runtime/-/runtime-7.4.5.tgz",
-      "integrity": "sha1-WCu1MfX53GfS/LaCl5iU914lPxI=",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
+      "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -826,7 +761,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/template/-/template-7.4.4.tgz",
       "integrity": "sha1-9LiNEiVomgj1vDoXSDVFvp5O0jc=",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/parser": "^7.4.4",
@@ -837,7 +771,6 @@
       "version": "7.4.5",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/traverse/-/traverse-7.4.5.tgz",
       "integrity": "sha1-TpLRco/S8Yl9r90yHvv/khVsMhY=",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/generator": "^7.4.4",
@@ -854,7 +787,6 @@
       "version": "7.4.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/@babel/types/-/types-7.4.4.tgz",
       "integrity": "sha1-jbnppim7fCk3AAm0t3ntk/5X1fA=",
-      "dev": true,
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.17.11",
@@ -1266,7 +1198,6 @@
       "version": "3.2.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -1381,8 +1312,8 @@
     },
     "ast-metadata-inferer": {
       "version": "0.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/ast-metadata-inferer/-/ast-metadata-inferer-0.1.1.tgz",
-      "integrity": "sha1-ZuJPrp0wypYfrEiAt/xGbwmyUWU=",
+      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.1.1.tgz",
+      "integrity": "sha512-hc9w8Qrgg9Lf9iFcZVhNjUnhrd2BBpTlyCnegPVvCe6O0yMrF57a6Cmh7k+xUsfUOMh9wajOL5AsGOBNEyTCcw==",
       "dev": true
     },
     "ast-types-flow": {
@@ -1429,17 +1360,17 @@
     },
     "axobject-query": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/axobject-query/-/axobject-query-2.0.2.tgz",
-      "integrity": "sha1-6hh6vluQArN3+SXYv30cVhrfOPk=",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
+      "integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
       "dev": true,
       "requires": {
         "ast-types-flow": "0.0.7"
       }
     },
     "babel-eslint": {
-      "version": "10.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/babel-eslint/-/babel-eslint-10.0.1.tgz",
-      "integrity": "sha1-kZaB3AmWFM19MdRciQhpUJKh+u0=",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.2.tgz",
+      "integrity": "sha512-UdsurWPtgiPgpJ06ryUnuaSXC2s0WoSZnQmEpbAH65XZSdwowgN5MvyP7e88nW07FYXv72erVtpBkxyDVKhH1Q==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1489,7 +1420,6 @@
       "version": "1.10.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.0.tgz",
       "integrity": "sha1-/x9CrSzHjCHya2Ima49WTbyGKTk=",
-      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-module-imports": "^7.0.0",
@@ -1500,14 +1430,7 @@
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-      "dev": true
-    },
-    "babel-plugin-transform-react-remove-prop-types": {
-      "version": "0.4.24",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
-      "integrity": "sha1-8u2vm0xqX75cHWeL+1MQeMFVXzo=",
-      "dev": true
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-preset-jest": {
       "version": "24.6.0",
@@ -1519,10 +1442,15 @@
         "babel-plugin-jest-hoist": "^24.6.0"
       }
     },
+    "babelify": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/babelify/-/babelify-10.0.0.tgz",
+      "integrity": "sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg=="
+    },
     "baconjs": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/baconjs/-/baconjs-1.0.1.tgz",
-      "integrity": "sha1-O7PMFEJoQMBvsLYt1BCl4l/hPV0=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/baconjs/-/baconjs-3.0.3.tgz",
+      "integrity": "sha512-G2fYXRmgSonjNjTclY5gKU9qXNcp05pDIYA0F2H4NEDG1yXApfzK1iS12B9HI7hfv9+hOFDApoXsL5pDPrSFXg==",
       "dev": true
     },
     "balanced-match": {
@@ -1661,7 +1589,6 @@
       "version": "4.6.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/browserslist/-/browserslist-4.6.0.tgz",
       "integrity": "sha1-UnQCjCb02TPVsTIzB8HR2lCEyf8=",
-      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30000967",
         "electron-to-chromium": "^1.3.133",
@@ -1725,16 +1652,15 @@
       "dev": true
     },
     "caniuse-db": {
-      "version": "1.0.30000971",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/caniuse-db/-/caniuse-db-1.0.30000971.tgz",
-      "integrity": "sha1-VTAlChRqj+wPrjAUyUwqrgQMbL4=",
+      "version": "1.0.30000975",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000975.tgz",
+      "integrity": "sha512-4Ht47eUW0uaOhuCs7bc7BhWqhP7ix3QCxcY7VLRLmw81AOz8S9A6pjTajxTDakQc+T/zTnUdy4iSmt5brSNxxw==",
       "dev": true
     },
     "caniuse-lite": {
       "version": "1.0.30000971",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/caniuse-lite/-/caniuse-lite-1.0.30000971.tgz",
-      "integrity": "sha1-0QAORUZIaml3dWVHNSvJakz9KxM=",
-      "dev": true
+      "integrity": "sha1-0QAORUZIaml3dWVHNSvJakz9KxM="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -1755,7 +1681,6 @@
       "version": "2.4.2",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1849,7 +1774,6 @@
       "version": "1.9.3",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1857,8 +1781,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -1877,8 +1800,8 @@
     },
     "comment-parser": {
       "version": "0.5.4",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/comment-parser/-/comment-parser-0.5.4.tgz",
-      "integrity": "sha1-CJhAuczKytK3abIx7UMIHVAblIc=",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.5.4.tgz",
+      "integrity": "sha512-0h7W6Y1Kb6zKQMJqdX41C5qf9ITCVIsD2qP2RaqDF3GFkXFrmuAuv5zUOuo19YzyC9scjBNpqzuaRQ2Sy5pxMQ==",
       "dev": true
     },
     "component-emitter": {
@@ -1944,7 +1867,6 @@
       "version": "1.6.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/convert-source-map/-/convert-source-map-1.6.0.tgz",
       "integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
       }
@@ -1959,7 +1881,6 @@
       "version": "3.1.2",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/core-js-compat/-/core-js-compat-3.1.2.tgz",
       "integrity": "sha1-wpq5ciUXCUuYYiF14iGMO3OYF20=",
-      "dev": true,
       "requires": {
         "browserslist": "^4.6.0",
         "core-js-pure": "3.1.2",
@@ -1969,16 +1890,14 @@
         "semver": {
           "version": "6.1.0",
           "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/semver/-/semver-6.1.0.tgz",
-          "integrity": "sha1-6V3EFdRezwPy+fg7JkprEfScDMo=",
-          "dev": true
+          "integrity": "sha1-6V3EFdRezwPy+fg7JkprEfScDMo="
         }
       }
     },
     "core-js-pure": {
       "version": "3.1.2",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/core-js-pure/-/core-js-pure-3.1.2.tgz",
-      "integrity": "sha1-YvxDXzW3N0ubeCATzcsvl+n23/o=",
-      "dev": true
+      "integrity": "sha1-YvxDXzW3N0ubeCATzcsvl+n23/o="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2043,8 +1962,8 @@
     },
     "damerau-levenshtein": {
       "version": "1.0.5",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
-      "integrity": "sha1-eAz3FE6y6NvRw7uDrjEQDMwxpBQ=",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
+      "integrity": "sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA==",
       "dev": true
     },
     "dashdash": {
@@ -2084,7 +2003,6 @@
       "version": "4.1.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/debug/-/debug-4.1.1.tgz",
       "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -2218,8 +2136,7 @@
     "electron-to-chromium": {
       "version": "1.3.137",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/electron-to-chromium/-/electron-to-chromium-1.3.137.tgz",
-      "integrity": "sha1-unyIAkmEwDilxcQ0Upqrzqe0KUQ=",
-      "dev": true
+      "integrity": "sha1-unyIAkmEwDilxcQ0Upqrzqe0KUQ="
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -2234,6 +2151,15 @@
       "dev": true,
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "envify": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/envify/-/envify-4.1.0.tgz",
+      "integrity": "sha512-IKRVVoAYr4pIx4yIWNsz9mOsboxlNXiu7TNBnem/K/uTHdkyzXWDzHCK7UTolqBbgaBz0tQHsD3YNls0uIIjiw==",
+      "requires": {
+        "esprima": "^4.0.0",
+        "through": "~2.3.4"
       }
     },
     "error-ex": {
@@ -2273,8 +2199,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.11.1",
@@ -2361,9 +2286,9 @@
       }
     },
     "eslint-config-foxsports": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/eslint-config-foxsports/-/eslint-config-foxsports-0.1.1.tgz",
-      "integrity": "sha1-N1DA+UZNlhlqQ0Tl+1MNIG6+nzI=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-foxsports/-/eslint-config-foxsports-0.1.2.tgz",
+      "integrity": "sha512-BtgdnafUBtq3RZ8YdAVVDyc+KqaRaK/oByafDcHIVZO4T4+vmoD0cf5rCHvWkK+HHpRuuQZKYu7evOCK4iPcag==",
       "dev": true,
       "requires": {
         "babel-eslint": "^10.0.1",
@@ -2378,8 +2303,8 @@
     },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
-      "integrity": "sha1-WPFfuDm40FdsqYBBNHaqskcttmo=",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
         "debug": "^2.6.9",
@@ -2388,8 +2313,8 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -2405,8 +2330,8 @@
     },
     "eslint-module-utils": {
       "version": "2.4.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
-      "integrity": "sha1-i5NJnpsA6rgMy2YU5p8DZ46E4Jo=",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
+      "integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
       "dev": true,
       "requires": {
         "debug": "^2.6.8",
@@ -2415,8 +2340,8 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -2431,23 +2356,31 @@
       }
     },
     "eslint-plugin-compat": {
-      "version": "3.1.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/eslint-plugin-compat/-/eslint-plugin-compat-3.1.1.tgz",
-      "integrity": "sha1-XsNn267EIpKIlOa09wiqYj8joZg=",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-3.1.2.tgz",
+      "integrity": "sha512-10XuVdl1RG53EvXNep6VwVsIbXsJM/g+M2fCvMTuw5CSVeITAw108HjC79+NPwrBbYFpdOfeIR08CviBDZQDKg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.4.2",
+        "@babel/runtime": "^7.4.5",
         "ast-metadata-inferer": "^0.1.1",
-        "browserslist": "^4.5.2",
-        "caniuse-db": "^1.0.30000951",
-        "mdn-browser-compat-data": "^0.0.72",
-        "semver": "^5.6.0"
+        "browserslist": "^4.5.4",
+        "caniuse-db": "^1.0.30000957",
+        "mdn-browser-compat-data": "^0.0.74",
+        "semver": "^6.1.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+          "integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-filenames": {
       "version": "1.3.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/eslint-plugin-filenames/-/eslint-plugin-filenames-1.3.2.tgz",
-      "integrity": "sha1-cJTwDXrv3WmZ46wZ9yzqBY5ZDPc=",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-filenames/-/eslint-plugin-filenames-1.3.2.tgz",
+      "integrity": "sha512-tqxJTiEM5a0JmRCUYQmxw23vtTxrb2+a3Q2mMOPhFxvt7ZQQJmdiuMby9B/vUAuVMghyP7oET+nIf6EO6CBd/w==",
       "dev": true,
       "requires": {
         "lodash.camelcase": "4.3.0",
@@ -2458,8 +2391,8 @@
     },
     "eslint-plugin-import": {
       "version": "2.17.3",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/eslint-plugin-import/-/eslint-plugin-import-2.17.3.tgz",
-      "integrity": "sha1-AFSLRDTBj666ugSySuYZjygN4Yk=",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.17.3.tgz",
+      "integrity": "sha512-qeVf/UwXFJbeyLbxuY8RgqDyEKCkqV7YC+E5S5uOjAp4tOc8zj01JP3ucoBM8JcEqd1qRasJSg6LLlisirfy0Q==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
@@ -2477,8 +2410,8 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -2533,8 +2466,8 @@
         },
         "p-limit": {
           "version": "1.3.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
             "p-try": "^1.0.0"
@@ -2604,8 +2537,8 @@
     },
     "eslint-plugin-jsdoc": {
       "version": "5.0.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-5.0.2.tgz",
-      "integrity": "sha1-M4ehFlEc4YgAhnC76lmN7B3hFUk=",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-5.0.2.tgz",
+      "integrity": "sha512-ACSu4NEEG5KZK7liCZz9jm5f5hFHcCL29zsN0RTixIZe1kuZOVO3oVbvnpe6o/U/3h9dMLJ42Yhe6umBS6aO7A==",
       "dev": true,
       "requires": {
         "comment-parser": "^0.5.4",
@@ -2615,8 +2548,8 @@
     },
     "eslint-plugin-jsx-a11y": {
       "version": "6.2.1",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",
-      "integrity": "sha1-Trup8zm2AP9BWuQWbj4uAIgxzww=",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",
+      "integrity": "sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==",
       "dev": true,
       "requires": {
         "aria-query": "^3.0.0",
@@ -2631,8 +2564,8 @@
     },
     "eslint-plugin-react": {
       "version": "7.13.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/eslint-plugin-react/-/eslint-plugin-react-7.13.0.tgz",
-      "integrity": "sha1-vBP9cQHeZ5lupRszhzzZ3Ct+V1g=",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.13.0.tgz",
+      "integrity": "sha512-uA5LrHylu8lW/eAH3bEQe9YdzpPaFd9yAJTwTi/i/BKTD7j6aQMKVAdGM/ML72zD6womuSK7EiGtMKuK06lWjQ==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
@@ -2646,8 +2579,8 @@
       "dependencies": {
         "doctrine": {
           "version": "2.1.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2"
@@ -2691,8 +2624,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
-      "dev": true
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
     },
     "esquery": {
       "version": "1.0.1",
@@ -2727,8 +2659,7 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "exec-sh": {
       "version": "0.3.2",
@@ -3082,7 +3013,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3103,12 +3035,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3123,17 +3057,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3250,7 +3187,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3262,6 +3200,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3276,6 +3215,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3283,12 +3223,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3307,6 +3249,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3387,7 +3330,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3399,6 +3343,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3484,7 +3429,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3520,6 +3466,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3539,6 +3486,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3582,12 +3530,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3650,8 +3600,7 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
-      "dev": true
+      "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4="
     },
     "graceful-fs": {
       "version": "4.1.15",
@@ -3713,8 +3662,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -3904,7 +3852,6 @@
       "version": "2.2.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -4659,14 +4606,12 @@
     "js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
-      "integrity": "sha1-xs7ljrNVA3LfjeuF+tXOZs4B1Z0=",
-      "dev": true
+      "integrity": "sha1-xs7ljrNVA3LfjeuF+tXOZs4B1Z0="
     },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
-      "dev": true
+      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -4686,8 +4631,8 @@
     },
     "jsdoctypeparser": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/jsdoctypeparser/-/jsdoctypeparser-3.1.0.tgz",
-      "integrity": "sha1-L2X3UWXE2cYyu0/aE+02t4MhpDs=",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-3.1.0.tgz",
+      "integrity": "sha512-JNbkKpDFqbYjg+IU3FNo7qjX7Opy7CwjHywT32zgAcz/d4lX6Umn5jOHVETUdnNNgGrMk0nEx1gvP0F4M0hzlQ==",
       "dev": true
     },
     "jsdom": {
@@ -4735,8 +4680,7 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
-      "dev": true
+      "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -4772,7 +4716,6 @@
       "version": "2.1.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/json5/-/json5-2.1.0.tgz",
       "integrity": "sha1-56DGLEgoXGKNIKELhcibuAfDKFA=",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.0"
       }
@@ -4797,8 +4740,8 @@
     },
     "jsx-ast-utils": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/jsx-ast-utils/-/jsx-ast-utils-2.1.0.tgz",
-      "integrity": "sha1-DuTiyXH7lgHGe1ZBtxvoD67PCzY=",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.1.0.tgz",
+      "integrity": "sha512-yDGDG2DS4JcqhA6blsuYbtsT09xL8AoLuUR2Gb5exrw7UEM19sBcOTq+YBBhrNbl0PUC4R4LnFu+dHg2HKeVvA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3"
@@ -4872,8 +4815,7 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40=",
-      "dev": true
+      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -4909,7 +4851,6 @@
       "version": "1.4.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -4985,9 +4926,9 @@
       }
     },
     "mdn-browser-compat-data": {
-      "version": "0.0.72",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.72.tgz",
-      "integrity": "sha1-sdICa/v2HILnHEFXBZudFhyHkak=",
+      "version": "0.0.74",
+      "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.74.tgz",
+      "integrity": "sha512-d/pTMwk3tMxdBb5ziOr3wHLFJRfYqSgGMt5aKLpCDBFYu6gk/uLGibkikv/HmMJyU3GEb9R1VvkVkCw75hVMvg==",
       "dev": true,
       "requires": {
         "extend": "3.0.2"
@@ -5092,8 +5033,7 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -5136,8 +5076,7 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
-      "dev": true
+      "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -5218,7 +5157,6 @@
       "version": "1.1.21",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/node-releases/-/node-releases-1.1.21.tgz",
       "integrity": "sha1-RshvmtrOrk1jx108Ly5u7mGOVfM=",
-      "dev": true,
       "requires": {
         "semver": "^5.3.0"
       }
@@ -5352,8 +5290,8 @@
     },
     "object.fromentries": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/object.fromentries/-/object.fromentries-2.0.0.tgz",
-      "integrity": "sha1-SaVD2SFR+Cd7OslgDx6TCxidMKs=",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
+      "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
@@ -5585,8 +5523,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
-      "dev": true
+      "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw="
     },
     "path-type": {
       "version": "3.0.0",
@@ -5654,8 +5591,8 @@
         },
         "p-limit": {
           "version": "1.3.0",
-          "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
             "p-try": "^1.0.0"
@@ -5747,8 +5684,7 @@
     "private": {
       "version": "0.1.8",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/private/-/private-0.1.8.tgz",
-      "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8=",
-      "dev": true
+      "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8="
     },
     "process-nextick-args": {
       "version": "2.0.0",
@@ -5901,28 +5837,25 @@
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/regenerate/-/regenerate-1.4.0.tgz",
-      "integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE=",
-      "dev": true
+      "integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE="
     },
     "regenerate-unicode-properties": {
       "version": "8.1.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
       "integrity": "sha1-71Hg8OpK1CS3e/fLQfPgFccKPw4=",
-      "dev": true,
       "requires": {
         "regenerate": "^1.4.0"
       }
     },
     "regenerator-runtime": {
       "version": "0.13.2",
-      "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-      "integrity": "sha1-MuWcmm+5saSv8JtJMMotRHc0NEc="
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
     },
     "regenerator-transform": {
       "version": "0.14.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/regenerator-transform/-/regenerator-transform-0.14.0.tgz",
       "integrity": "sha1-LKmq96LCOd0y5HYSGEJbjHqG7K8=",
-      "dev": true,
       "requires": {
         "private": "^0.1.6"
       }
@@ -5940,8 +5873,7 @@
     "regexp-tree": {
       "version": "0.1.10",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/regexp-tree/-/regexp-tree-0.1.10.tgz",
-      "integrity": "sha1-2DeBagOcevio1k16fDz2odk0ULw=",
-      "dev": true
+      "integrity": "sha1-2DeBagOcevio1k16fDz2odk0ULw="
     },
     "regexpp": {
       "version": "2.0.1",
@@ -5953,7 +5885,6 @@
       "version": "4.5.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/regexpu-core/-/regexpu-core-4.5.4.tgz",
       "integrity": "sha1-CA2dAiiaqH/hZnpPUTa8mKauuq4=",
-      "dev": true,
       "requires": {
         "regenerate": "^1.4.0",
         "regenerate-unicode-properties": "^8.0.2",
@@ -5966,14 +5897,12 @@
     "regjsgen": {
       "version": "0.5.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/regjsgen/-/regjsgen-0.5.0.tgz",
-      "integrity": "sha1-p2NNwI+JIJwgSa3aNSVxH7lyZd0=",
-      "dev": true
+      "integrity": "sha1-p2NNwI+JIJwgSa3aNSVxH7lyZd0="
     },
     "regjsparser": {
       "version": "0.6.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/regjsparser/-/regjsparser-0.6.0.tgz",
       "integrity": "sha1-8eaui32iuulsmTmbhozWyTOiupw=",
-      "dev": true,
       "requires": {
         "jsesc": "~0.5.0"
       },
@@ -5981,8 +5910,7 @@
         "jsesc": {
           "version": "0.5.0",
           "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-          "dev": true
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
     },
@@ -6086,7 +6014,6 @@
       "version": "1.11.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/resolve/-/resolve-1.11.0.tgz",
       "integrity": "sha1-QBSHC6KWF2uGND1Qtg87UGCc4jI=",
-      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -6259,8 +6186,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "dev": true
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -6313,8 +6239,7 @@
     "semver": {
       "version": "5.7.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws=",
-      "dev": true
+      "integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
     },
     "serialize-javascript": {
       "version": "1.7.0",
@@ -6543,8 +6468,7 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -6788,7 +6712,6 @@
       "version": "5.5.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -6885,8 +6808,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tmp": {
       "version": "0.0.33",
@@ -6906,8 +6828,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -6973,8 +6894,7 @@
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "tslib": {
       "version": "1.9.3",
@@ -7029,14 +6949,12 @@
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-      "integrity": "sha1-JhmADEyCWADv3YNDr33Zkzy+KBg=",
-      "dev": true
+      "integrity": "sha1-JhmADEyCWADv3YNDr33Zkzy+KBg="
     },
     "unicode-match-property-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
       "integrity": "sha1-jtKjJWmWG86SJ9Cc0/+7j+1fAgw=",
-      "dev": true,
       "requires": {
         "unicode-canonical-property-names-ecmascript": "^1.0.4",
         "unicode-property-aliases-ecmascript": "^1.0.4"
@@ -7045,14 +6963,12 @@
     "unicode-match-property-value-ecmascript": {
       "version": "1.1.0",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
-      "integrity": "sha1-W0tCbgjROoA2Xg1lesemwexGonc=",
-      "dev": true
+      "integrity": "sha1-W0tCbgjROoA2Xg1lesemwexGonc="
     },
     "unicode-property-aliases-ecmascript": {
       "version": "1.0.5",
       "resolved": "https://artifactory.foxsports.com.au:443/api/npm/npm-remote/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
-      "integrity": "sha1-qcxsx85joKMCP8meNBuUQx1AWlc=",
-      "dev": true
+      "integrity": "sha1-qcxsx85joKMCP8meNBuUQx1AWlc="
     },
     "union-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,11 @@
 {
-  "name": "@isoreact/bacon1",
+  "name": "@isoreact/bacon",
   "version": "1.4.0",
-  "description": "A library for making isomorphic React components with Bacon.js 1",
+  "description": "A library for making isomorphic React components with Bacon.js",
   "author": "Steve Taylor",
   "license": "MIT",
-  "repository": "isoreact/bacon1",
-  "main": "dist/index.js",
-  "files": [
-    "dist/"
-  ],
+  "repository": "isoreact/bacon",
+  "main": "src/index.js",
   "publishConfig": {
     "access": "public"
   },
@@ -44,32 +41,39 @@
       "./test/serializers/render-to-html-serializer"
     ]
   },
+  "browserify": {
+    "transform": [
+      "envify",
+      "babelify"
+    ]
+  },
   "peerDependencies": {
-    "baconjs": ">=1 <3",
+    "baconjs": ">=0.7.59 <4",
     "prop-types": "^15.6.2",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "styled-components": ">=3.3.3"
   },
   "dependencies": {
+    "@babel/core": "^7.3.3",
+    "@babel/plugin-proposal-class-properties": "^7.3.3",
+    "@babel/plugin-transform-runtime": "^7.4.4",
+    "@babel/preset-env": "^7.3.1",
+    "@babel/preset-react": "^7.0.0",
+    "@babel/runtime": "^7.4.5",
+    "babel-plugin-styled-components": "^1.10.0",
+    "babelify": "^10.0.0",
+    "envify": "^4.1.0",
     "hash.js": "^1.1.5",
-    "regenerator-runtime": "^0.13.1",
     "serialize-javascript": "^1.6.1",
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@babel/core": "^7.3.3",
-    "@babel/plugin-proposal-class-properties": "^7.3.3",
-    "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
-    "@babel/preset-env": "^7.3.1",
-    "@babel/preset-react": "^7.0.0",
     "babel-jest": "^24.1.0",
-    "babel-plugin-styled-components": "^1.10.0",
-    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-    "baconjs": "^1.0.1",
+    "baconjs": "^3.0.3",
     "cross-env": "^5.2.0",
     "eslint": "^5.16.0",
-    "eslint-config-foxsports": "^0.1.1",
+    "eslint-config-foxsports": "^0.1.2",
     "jest": "^24.1.0",
     "npm-run-all": "^4.1.5",
     "pretty": "^2.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,7 +18,7 @@ export default ['development', 'production'].map((environment) => ({
             'react-dom/server': 'ReactDOMServer',
         },
         file: [
-            'dist/isoreact-bacon1.cjs',
+            'dist/isoreact-bacon.cjs',
             environment === 'production' && 'min',
             'js',
         ]
@@ -28,35 +28,7 @@ export default ['development', 'production'].map((environment) => ({
     plugins: [
         sourceMaps(),
         nodeResolve(),
-        babel({
-            babelrc: false,
-            presets: [
-                [
-                    '@babel/preset-env',
-                    {
-                        modules: false,
-                        targets: {node: '10.0.0', browsers: ['last 2 versions']},
-                    },
-                ],
-                '@babel/preset-react',
-            ]
-                .filter(Boolean),
-            plugins: [
-                '@babel/plugin-proposal-object-rest-spread',
-                '@babel/plugin-proposal-class-properties',
-                [
-                    'babel-plugin-styled-components',
-                    {
-                        ssr: true,
-                        displayName: true,
-                        fileName: false,
-                    },
-                ],
-                environment === 'production' && 'babel-plugin-transform-react-remove-prop-types',
-            ]
-                .filter(Boolean),
-            exclude: 'node_modules/**',
-        }),
+        babel({runtimeHelpers: true}),
         commonjs(),
         replace({
             'process.env.NODE_ENV': `"${environment}"`,

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-import 'regenerator-runtime/runtime'; // eslint-disable-line import/no-unassigned-import
-
 // Common
 export {default as Connect} from './connect';
 export {default as isomorphic} from './isomorphic';

--- a/src/render-to-html.js
+++ b/src/render-to-html.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
-import bacon from 'baconjs';
+import {combineAsArray} from 'baconjs';
 import uuid from 'uuid/v1';
 import serialize from 'serialize-javascript';
 
@@ -70,17 +70,16 @@ export default async function renderToHtml(
         const keys = [...pendingKeys];
 
         // Wait for all of them to resolve.
-        await bacon
-            .combineAsArray(
-                keys.map((key) => (
-                    registeredStreams[key]
-                        .first()
-                        .doAction(({hydration: h}) => {
-                            hydration[key] = h;
-                            pendingKeys.delete(key);
-                        })
-                ))
-            )
+        await combineAsArray(
+            keys.map((key) => (
+                registeredStreams[key]
+                    .first()
+                    .doAction(({hydration: h}) => {
+                        hydration[key] = h;
+                        pendingKeys.delete(key);
+                    })
+            ))
+        )
             .firstToPromise();
 
         // Remove them from pendingKeys, which may have had more keys added while waiting.

--- a/src/use-isomorphic-context.js
+++ b/src/use-isomorphic-context.js
@@ -1,5 +1,5 @@
 import {useContext, useLayoutEffect, useRef, useState} from 'react';
-import bacon from 'baconjs';
+import {Bus} from 'baconjs';
 
 import {IsomorphicContext, HYDRATION, SERVER} from './context';
 import {noImmediateStateOnHydrationError, noImmediateStateOnRenderError, noImmediateStateOnServerError} from './errors';
@@ -34,13 +34,13 @@ export default function useIsomorphicContext(context, isEqual) {
         const subscription = useRef(null);
 
         // data$ stream switching
-        const [bus] = useState(() => new bacon.Bus());
+        const [bus] = useState(() => new Bus());
         const [switchedData$] = useState(() => (
             bus
-                .startWith(data$)
+                .toProperty(data$) // this needs to be synchronous, which rules out startsWith as of Bacon v2
                 .skipDuplicates()
                 .flatMapLatest((stream$) => stream$)
-                .toProperty()
+                .toProperty()      // required by older versions of Bacon to keep this a Property
         ));
 
         bus.push(data$); // switch streams

--- a/test/__snapshots__/render-to-html.test.js.snap
+++ b/test/__snapshots__/render-to-html.test.js.snap
@@ -106,15 +106,15 @@ exports[`renderToHtml(isomorphicComponent) <Connect /> simple isomorphic compone
 
 exports[`renderToHtml(isomorphicComponent) <Connect /> styled nested isomorphic component renders correctly 1`] = `
 <head>
-  <style data-styled="bLXHOZ gjNiSI" data-styled-version="4.2.0">
-    /* sc-component-id: StyledSection-sc-1e5fo1a-0 */
-    .bLXHOZ {
+  <style data-styled="fXyZxv clzntv" data-styled-version="4.2.0">
+    /* sc-component-id: StyledSection-ng6vb3-0 */
+    .fXyZxv {
       padding: 7px;
       background: #bbb;
     }
 
-    /* sc-component-id: StyledList-sc-1e5fo1a-1 */
-    .gjNiSI {
+    /* sc-component-id: StyledList-ng6vb3-1 */
+    .clzntv {
       margin: 7px;
       background: #666;
       color: #ddd;
@@ -124,8 +124,8 @@ exports[`renderToHtml(isomorphicComponent) <Connect /> styled nested isomorphic 
 
 <body>
   <div id="0123456789abcdef">
-    <section class="StyledSection-sc-1e5fo1a-0 bLXHOZ">
-      <ul class="StyledList-sc-1e5fo1a-1 gjNiSI">
+    <section class="StyledSection-ng6vb3-0 fXyZxv">
+      <ul class="StyledList-ng6vb3-1 clzntv">
         <li>27</li>
         <li>72</li>
         <li>
@@ -273,15 +273,15 @@ exports[`renderToHtml(isomorphicComponent) useIsomorphicContext() simple isomorp
 
 exports[`renderToHtml(isomorphicComponent) useIsomorphicContext() styled nested isomorphic component renders correctly 1`] = `
 <head>
-  <style data-styled="Duetr ceUwuZ" data-styled-version="4.2.0">
-    /* sc-component-id: StyledSection-xukvp3-0 */
-    .Duetr {
+  <style data-styled="jurjOT gHppZD" data-styled-version="4.2.0">
+    /* sc-component-id: StyledSection-xs7l9v-0 */
+    .jurjOT {
       padding: 7px;
       background: #bbb;
     }
 
-    /* sc-component-id: StyledList-xukvp3-1 */
-    .ceUwuZ {
+    /* sc-component-id: StyledList-xs7l9v-1 */
+    .gHppZD {
       margin: 7px;
       background: #666;
       color: #ddd;
@@ -291,8 +291,8 @@ exports[`renderToHtml(isomorphicComponent) useIsomorphicContext() styled nested 
 
 <body>
   <div id="0123456789abcdef">
-    <section class="StyledSection-xukvp3-0 Duetr">
-      <ul class="StyledList-xukvp3-1 ceUwuZ">
+    <section class="StyledSection-xs7l9v-0 jurjOT">
+      <ul class="StyledList-xs7l9v-1 gHppZD">
         <li>27</li>
         <li>72</li>
         <li>

--- a/test/data/connect/isomorphic/iso-nested-with-styles.js
+++ b/test/data/connect/isomorphic/iso-nested-with-styles.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import hydrate from '../../../../src/hydrate';
 import isomorphic from '../../../../src/isomorphic';
 
@@ -12,9 +10,6 @@ const isoNestedWithStyles = {
     component: NestedWithStyles,
     context: NestedWithStylesContext,
     getData,
-    propTypes: {
-        coefficient: propTypes.number,
-    },
 };
 
 export const IsoNestedWithStyles = isomorphic(isoNestedWithStyles);

--- a/test/data/connect/isomorphic/iso-nested.js
+++ b/test/data/connect/isomorphic/iso-nested.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import hydrate from '../../../../src/hydrate';
 import isomorphic from '../../../../src/isomorphic';
 
@@ -12,9 +10,6 @@ const isoNested = {
     component: Nested,
     context: NestedContext,
     getData,
-    propTypes: {
-        coefficient: propTypes.number,
-    },
 };
 
 export const IsoNested = isomorphic(isoNested);

--- a/test/data/connect/isomorphic/iso-simple.js
+++ b/test/data/connect/isomorphic/iso-simple.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import hydrate from '../../../../src/hydrate';
 import isomorphic from '../../../../src/isomorphic';
 
@@ -12,9 +10,6 @@ const isoSimple = {
     component: Simple,
     context: SimpleContext,
     getData,
-    propTypes: {
-        power: propTypes.number,
-    },
 };
 
 export const IsoSimple = isomorphic(isoSimple);

--- a/test/data/connect/isomorphic/iso-throws-delayed-error.js
+++ b/test/data/connect/isomorphic/iso-throws-delayed-error.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import hydrate from '../../../../src/hydrate';
 import isomorphic from '../../../../src/isomorphic';
 
@@ -12,9 +10,6 @@ const isoThrowsDelayedError = {
     component: ThrowsError,
     context: ThrowsErrorContext,
     getData,
-    propTypes: {
-        power: propTypes.number,
-    },
 };
 
 export const IsoThrowsDelayedError = isomorphic(isoThrowsDelayedError);

--- a/test/data/connect/isomorphic/iso-throws-immediate-error.js
+++ b/test/data/connect/isomorphic/iso-throws-immediate-error.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import hydrate from '../../../../src/hydrate';
 import isomorphic from '../../../../src/isomorphic';
 
@@ -12,9 +10,6 @@ const isoThrowsImmediateError = {
     component: ThrowsError,
     context: ThrowsErrorContext,
     getData,
-    propTypes: {
-        power: propTypes.number,
-    },
 };
 
 export const IsoThrowsImmediateError = isomorphic(isoThrowsImmediateError);

--- a/test/data/connect/isomorphic/iso-very-simple.js
+++ b/test/data/connect/isomorphic/iso-very-simple.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import hydrate from '../../../../src/hydrate';
 import isomorphic from '../../../../src/isomorphic';
 
@@ -12,9 +10,6 @@ const isoVerySimple = {
     component: VerySimple,
     context: VerySimpleContext,
     getData,
-    propTypes: {
-        power: propTypes.number,
-    },
 };
 
 export const IsoVerySimple = isomorphic(isoVerySimple);

--- a/test/data/hooks/isomorphic/iso-nested-with-styles.js
+++ b/test/data/hooks/isomorphic/iso-nested-with-styles.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import hydrate from '../../../../src/hydrate';
 import isomorphic from '../../../../src/isomorphic';
 
@@ -12,9 +10,6 @@ const isoNestedWithStyles = {
     component: NestedWithStyles,
     context: NestedWithStylesContext,
     getData,
-    propTypes: {
-        coefficient: propTypes.number,
-    },
 };
 
 export const IsoNestedWithStyles = isomorphic(isoNestedWithStyles);

--- a/test/data/hooks/isomorphic/iso-nested.js
+++ b/test/data/hooks/isomorphic/iso-nested.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import hydrate from '../../../../src/hydrate';
 import isomorphic from '../../../../src/isomorphic';
 
@@ -12,9 +10,6 @@ const isoNested = {
     component: Nested,
     context: NestedContext,
     getData,
-    propTypes: {
-        coefficient: propTypes.number,
-    },
 };
 
 export const IsoNested = isomorphic(isoNested);

--- a/test/data/hooks/isomorphic/iso-simple.js
+++ b/test/data/hooks/isomorphic/iso-simple.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import hydrate from '../../../../src/hydrate';
 import isomorphic from '../../../../src/isomorphic';
 
@@ -12,9 +10,6 @@ const isoSimple = {
     component: Simple,
     context: SimpleContext,
     getData,
-    propTypes: {
-        power: propTypes.number,
-    },
 };
 
 export const IsoSimple = isomorphic(isoSimple);

--- a/test/data/hooks/isomorphic/iso-very-simple.js
+++ b/test/data/hooks/isomorphic/iso-very-simple.js
@@ -1,5 +1,3 @@
-import propTypes from 'prop-types';
-
 import hydrate from '../../../../src/hydrate';
 import isomorphic from '../../../../src/isomorphic';
 
@@ -12,9 +10,6 @@ const isoVerySimple = {
     component: VerySimple,
     context: VerySimpleContext,
     getData,
-    propTypes: {
-        power: propTypes.number,
-    },
 };
 
 export const IsoVerySimple = isomorphic(isoVerySimple);

--- a/test/data/iso-streams/nested-with-styles.js
+++ b/test/data/iso-streams/nested-with-styles.js
@@ -1,4 +1,4 @@
-import bacon from 'baconjs';
+import {combineTemplate, constant} from 'baconjs';
 import fetchV from '../streams/fetch-v';
 import fetchW from '../streams/fetch-w';
 
@@ -7,18 +7,18 @@ export default function getData(props, hydration) {
 
     // Get {v, w} from hydration if hydrating, or from an external data source if not hydrating.
     const v$ = hydration
-        ? bacon.constant(hydration.v)
+        ? constant(hydration.v)
         : fetchV();
 
     const w$ = hydration
-        ? bacon.constant(hydration.w)
+        ? constant(hydration.w)
         : fetchW();
 
     // Calculate {a, b} based on v (from external data source) and coefficient (from props)
     const a$ = v$.map((v) => coefficient * v);
     const b$ = w$.map((w) => coefficient * w);
 
-    return bacon.combineTemplate({
+    return combineTemplate({
         state: {
             a: a$,
             b: b$,

--- a/test/data/iso-streams/nested.js
+++ b/test/data/iso-streams/nested.js
@@ -1,4 +1,4 @@
-import bacon from 'baconjs';
+import {combineTemplate, constant} from 'baconjs';
 import fetchV from '../streams/fetch-v';
 import fetchW from '../streams/fetch-w';
 
@@ -7,32 +7,31 @@ export default function getData(props, hydration, immediate) {
 
     // Get {v, w} from hydration if hydrating, or from an external data source if not hydrating.
     const v$ = hydration
-        ? bacon.constant(hydration.v)
+        ? constant(hydration.v)
         : fetchV();
 
     const w$ = hydration
-        ? bacon.constant(hydration.w)
+        ? constant(hydration.w)
         : fetchW();
 
     // Calculate {a, b} based on v (from external data source) and coefficient (from props)
     const a$ = v$.map((v) => coefficient * v);
     const b$ = w$.map((w) => coefficient * w);
 
-    return bacon
-        .combineTemplate({
-            state: {
-                isLoading: false,
-                a: a$,
-                b: b$,
-            },
-            hydration: {
-                v: v$,
-                w: w$,
-            },
-            data: {
-                maxAge: 30,
-            },
-        })
+    return combineTemplate({
+        state: {
+            isLoading: false,
+            a: a$,
+            b: b$,
+        },
+        hydration: {
+            v: v$,
+            w: w$,
+        },
+        data: {
+            maxAge: 30,
+        },
+    })
         // Start with a loading state (which is skipped by Bacon.js when combineTemplate resolves immediately) ...
         .startWith({
             state: {

--- a/test/data/iso-streams/simple.js
+++ b/test/data/iso-streams/simple.js
@@ -1,4 +1,4 @@
-import bacon from 'baconjs';
+import {combineTemplate, constant} from 'baconjs';
 import fetchBaseValue from '../streams/fetch-base-value';
 
 export default function getData(props, hydration) {
@@ -6,13 +6,13 @@ export default function getData(props, hydration) {
 
     // Get baseValue from hydration if hydrating, or from an external data source if not hydrating.
     const baseValue$ = hydration
-        ? bacon.constant(hydration.baseValue)
+        ? constant(hydration.baseValue)
         : fetchBaseValue();
 
     // Calculate x based on baseValue (from external data source) and power (from props)
     const x$ = baseValue$.map((baseValue) => baseValue ** power);
 
-    return bacon.combineTemplate({
+    return combineTemplate({
         state: {
             x: x$,
         },

--- a/test/data/iso-streams/throws-delayed-error.js
+++ b/test/data/iso-streams/throws-delayed-error.js
@@ -1,8 +1,7 @@
-import bacon from 'baconjs';
+import {Error as BaconError, later} from 'baconjs';
 
 export default function getData() {
-    return bacon
-        .later(1, null)
-        .flatMapLatest(() => new bacon.Error('Nope!'))
+    return later(1, null)
+        .flatMapLatest(() => new BaconError('Nope!'))
         .toProperty();
 }

--- a/test/data/iso-streams/throws-immediate-error.js
+++ b/test/data/iso-streams/throws-immediate-error.js
@@ -1,8 +1,7 @@
-import bacon from 'baconjs';
+import {constant, Error as BaconError} from 'baconjs';
 
 export default function getData() {
-    return bacon
-        .constant(null)
-        .flatMapLatest(() => new bacon.Error('Nope!'))
+    return constant(null)
+        .flatMapLatest(() => new BaconError('Nope!'))
         .toProperty();
 }

--- a/test/data/iso-streams/very-simple.js
+++ b/test/data/iso-streams/very-simple.js
@@ -1,9 +1,9 @@
-import bacon from 'baconjs';
+import {combineTemplate} from 'baconjs';
 
 export default function getData(props) {
     const {power = 1} = props;
 
-    return bacon.combineTemplate({
+    return combineTemplate({
         state: {
             x: 5 ** power,
         },

--- a/test/data/streams/fetch-base-value.js
+++ b/test/data/streams/fetch-base-value.js
@@ -1,6 +1,6 @@
-import bacon from 'baconjs';
+import {later} from 'baconjs';
 
 // Simulated external data source
 export default function fetchBaseValue() {
-    return bacon.later(50, 5);
+    return later(50, 5);
 }

--- a/test/data/streams/fetch-v.js
+++ b/test/data/streams/fetch-v.js
@@ -1,6 +1,6 @@
-import bacon from 'baconjs';
+import {later} from 'baconjs';
 
 // Simulated external data source
 export default function fetchV() {
-    return bacon.later(50, 3);
+    return later(50, 3);
 }

--- a/test/data/streams/fetch-w.js
+++ b/test/data/streams/fetch-w.js
@@ -1,6 +1,6 @@
-import bacon from 'baconjs';
+import {later} from 'baconjs';
 
 // Simulated external data source
 export default function fetchW() {
-    return bacon.later(30, 8);
+    return later(30, 8);
 }


### PR DESCRIPTION
* Support Bacon versions [0.7.59, 4)
* Change package name
* Include source in distribution
* Import source by default
* Support Babel and Browserify when importing source