### PR TITLE
Make Browserify and Babel 7 play nice together

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,20 @@
   },
   "browserify": {
     "transform": [
-      "envify",
-      "babelify"
+      [
+        "babelify",
+        {
+          "presets": [
+            "@babel/preset-env",
+            "@babel/preset-react"
+          ],
+          "plugins": [
+            "@babel/plugin-transform-runtime",
+            "@babel/plugin-proposal-class-properties"
+          ]
+        }
+      ],
+      "envify"
     ]
   },
   "peerDependencies": {


### PR DESCRIPTION
Since version 7, Babel doesn't want to use dependencies' `.babelrc` files anymore.