### PR TITLE
Don't unmount on ref change

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -8,3 +8,7 @@ export const IsomorphicContext = React.createContext(() => null); // () => HYDRA
 
 export const HYDRATION = Symbol('hydration');
 export const SERVER = Symbol('ssr');
+
+ServerContext.displayName = 'ServerContext';
+HydrationContext.displayName = 'HydrationContext';
+IsomorphicContext.displayName = 'IsomorphicContext';

--- a/src/isomorphic.js
+++ b/src/isomorphic.js
@@ -186,7 +186,7 @@ export default function isomorphic({
                                     </ServerContext.Consumer>
                                 );
 
-                            case HYDRATION: // Hydrating or continuing to render after hydration
+                            case HYDRATION: // Hydrating
                                 if (!this.isHydrated) {
                                     this.isHydrated = true;
 
@@ -233,14 +233,22 @@ export default function isomorphic({
                                 }
 
                                 return (
-                                    <Context.Provider
-                                        value={{
-                                            data$: this.data$,
-                                            name,
-                                        }}
-                                    >
-                                        <Component ref={innerRef} />
-                                    </Context.Provider>
+                                    // If this component was hydrated (and now we're performing a post-hydration render),
+                                    // HydrationContext.Consumer was rendered in this position, so it needs to continue being rendered
+                                    // on post-hydration renders to prevent Component being unmounted and recreated. This only happens when
+                                    // this component's ref changes (see shouldComponentUpdate).
+                                    <HydrationContext.Consumer>
+                                        {() => (
+                                            <Context.Provider
+                                                value={{
+                                                    data$: this.data$,
+                                                    name,
+                                                }}
+                                            >
+                                                <Component ref={innerRef} />
+                                            </Context.Provider>
+                                        )}
+                                    </HydrationContext.Consumer>
                                 );
                             }
                         }

--- a/test/context-not-in-scope.test.js
+++ b/test/context-not-in-scope.test.js
@@ -36,7 +36,7 @@ describe('Context not in scope', () => {
         document.body.innerHTML = '';
     });
 
-    it('throws an error', () => {
+    test('it throws an error', () => {
         expect(consoleErrorSpy.mock.calls.slice(-1)[0][0]).toBe(
             'Cannot use Connect or useIsomorphicContext outside the scope of the isomorphic component to which the specified context belongs.'
         );

--- a/test/end-hydration-phase.test.js
+++ b/test/end-hydration-phase.test.js
@@ -96,11 +96,11 @@ describe('End hydration phase', () => {
         document.body.innerHTML = '';
     });
 
-    it('does not try to hydrate the child after hydration has occurred', async () => {
+    test('it does not try to hydrate the child after hydration has occurred', async () => {
         expect(document.querySelector('#error')).toBe(null);
     });
 
-    it('does not render the child in the context of the hydration render phase', () => {
+    test('it does not render the child in the context of the hydration render phase', () => {
         expect(document.querySelector('#phase').innerHTML).toBe('client');
     });
 });

--- a/test/ref-change-after-hydrate.test.js
+++ b/test/ref-change-after-hydrate.test.js
@@ -1,0 +1,93 @@
+import React, {useEffect, useRef, useState} from 'react';
+import ReactDOM from 'react-dom';
+import {Bus, combineTemplate} from 'baconjs';
+
+import hydrate from '../src/hydrate';
+import isomorphic from '../src/isomorphic';
+import renderToHtml from '../src/render-to-html';
+
+jest.mock('uuid/v1');
+require('uuid/v1').mockImplementation(() => '0123456789abcdef');
+
+describe('Change ref after hydration', () => {
+    let mounts = 0;
+
+    const bus = new Bus();
+
+    const Child = isomorphic({
+        name: 'child',
+        component: React.forwardRef((props, ref) => {
+            useEffect(
+                () => {
+                    ++mounts;
+                },
+                []
+            );
+
+            return (
+                <div ref={ref}>
+                    Child
+                </div>
+            );
+        }),
+        getData: (props$) => props$.map((state) => ({state})), // generate new state every time props change
+    });
+
+    const Parent = isomorphic({
+        name: 'parent',
+        component: () => {
+            const [refIndex, setRefIndex] = useState(0);
+            const childRefs = [useRef(null), useRef(null)];
+
+            // Make this component, and therefore the child, re-render.
+            useEffect(
+                () => {
+                    setRefIndex(1);
+                },
+                []
+            );
+
+            // Notify readiness to test
+            useEffect(
+                () => {
+                    if (refIndex === 1) {
+                        bus.push(null);
+                    }
+                },
+                [refIndex]
+            );
+
+            return (
+                <div>
+                    <Child ref={childRefs[refIndex]} />
+                </div>
+            );
+        },
+        getData: (props$) => combineTemplate({
+            state: {
+                shouldInitiallyRenderChild: props$.map(({shouldInitiallyRenderChild}) => shouldInitiallyRenderChild),
+            },
+        }),
+    });
+
+    beforeEach(async () => {
+        document.body.appendChild(document.createElement('div'));
+        document.body.innerHTML = await renderToHtml(<Parent />);
+        eval(document.querySelector('script').innerHTML);
+        hydrate(Parent);
+
+        // Wait until component updates are complete
+        await bus.firstToPromise();
+    });
+
+    afterEach(() => {
+        ReactDOM.unmountComponentAtNode(document.getElementById('0123456789abcdef'));
+        delete window.__ISO_DATA__;
+        document.body.innerHTML = '';
+        mounts = 0;
+    });
+
+    test('it mounts only once', () => {
+        expect(mounts).toBe(1);
+    });
+});

--- a/test/refs.test.js
+++ b/test/refs.test.js
@@ -52,7 +52,7 @@ describe('Forward refs to underlying component', () => {
                 ReactDOM.render(<Component />, mountElement);
             });
 
-            it('changes the root element\'s className', () => {
+            test('it changes the root element\'s className', () => {
                 expect(mountElement.querySelector('section').className).toBe('ref woz ere');
             });
         });

--- a/test/switch-stream.test.js
+++ b/test/switch-stream.test.js
@@ -48,7 +48,7 @@ describe('Isomorphic component props change', () => {
                 ReactDOM.render(<Component />, mountElement);
             });
 
-            it('updates UI', () => {
+            test('it updates UI', () => {
                 expect(mountElement.querySelector('section').innerHTML).toBe('25');
             });
         });


### PR DESCRIPTION
When an `isomorphic` component's `ref` is changed, `shouldComponentUpdate` returns `false` and the `render` method is called once again. If the component had hydrated, this causes the `render` method to take a different code path - one that generates a different React element structure than that when the component was hydrating. The change in element structure would cause the underlying component (the one passed to `isomorphic`'s `component` parameter) to unmount and be recreated.

This change ensures the element structure is the same in both cases, so that the underlying component isn't unmounted and recreated.